### PR TITLE
Add Gemini Weaver Divi plugin skeleton

### DIFF
--- a/gemini-weaver-divi/assets/css/gwd-style.css
+++ b/gemini-weaver-divi/assets/css/gwd-style.css
@@ -1,0 +1,3 @@
+#gwd-status {
+    margin-top: 10px;
+}

--- a/gemini-weaver-divi/assets/js/gwd-main.js
+++ b/gemini-weaver-divi/assets/js/gwd-main.js
@@ -1,0 +1,3 @@
+(function($){
+    console.log('Gemini Weaver Divi loaded');
+})(jQuery);

--- a/gemini-weaver-divi/gemini-weaver-divi.php
+++ b/gemini-weaver-divi/gemini-weaver-divi.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Plugin Name: Gemini Weaver Divi
+ * Description: Integrates generative design features into the Divi theme.
+ * Version: 1.0.0
+ * Author: Gemini Weaver
+ * Text Domain: gemini-weaver-divi
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+// Plugin path and URL constants.
+define( 'GWD_PATH', plugin_dir_path( __FILE__ ) );
+define( 'GWD_URL', plugin_dir_url( __FILE__ ) );
+
+/**
+ * Check if Divi theme is active.
+ *
+ * @return bool
+ */
+function gwd_is_divi_active() {
+    $theme = wp_get_theme();
+
+    if ( 'Divi' === $theme->get( 'Name' ) || 'Divi' === $theme->get( 'Template' ) ) {
+        return true;
+    }
+
+    if ( $theme->parent() && 'Divi' === $theme->parent()->get( 'Name' ) ) {
+        return true;
+    }
+
+    return false;
+}
+
+if ( ! gwd_is_divi_active() ) {
+    /**
+     * Display admin notice if Divi is not active.
+     */
+    add_action( 'admin_notices', function () {
+        echo '<div class="notice notice-warning"><p>' . esc_html__( 'Gemini Weaver Divi requires the Divi theme to be active.', 'gemini-weaver-divi' ) . '</p></div>';
+    } );
+
+    // Do not load further if Divi is not active.
+    return;
+}
+
+// Include metabox class.
+require_once GWD_PATH . 'includes/class-divi-metabox.php';
+
+/**
+ * Enqueue scripts and styles on the page editor screen.
+ */
+function gwd_enqueue_editor_assets( $hook ) {
+    global $pagenow;
+
+    if ( ! in_array( $pagenow, array( 'post.php', 'post-new.php' ), true ) ) {
+        return;
+    }
+
+    $screen = get_current_screen();
+
+    if ( 'page' !== $screen->post_type ) {
+        return;
+    }
+
+    wp_enqueue_script( 'gwd-main', GWD_URL . 'assets/js/gwd-main.js', array( 'jquery' ), '1.0.0', true );
+    wp_enqueue_style( 'gwd-style', GWD_URL . 'assets/css/gwd-style.css', array(), '1.0.0' );
+}
+add_action( 'admin_enqueue_scripts', 'gwd_enqueue_editor_assets' );

--- a/gemini-weaver-divi/includes/class-divi-metabox.php
+++ b/gemini-weaver-divi/includes/class-divi-metabox.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Divi metabox for Gemini Weaver Divi plugin.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+class GWD_Divi_Metabox {
+
+    public function __construct() {
+        add_action( 'add_meta_boxes', array( $this, 'add_metabox' ) );
+    }
+
+    /**
+     * Register the metabox.
+     */
+    public function add_metabox() {
+        add_meta_box(
+            'gwd-divi-metabox',
+            __( 'Diseñar con Gemini', 'gemini-weaver-divi' ),
+            array( $this, 'render' ),
+            'page',
+            'side',
+            'default'
+        );
+    }
+
+    /**
+     * Render the metabox HTML.
+     */
+    public function render() {
+        echo '<textarea id="gwd-prompt-input" style="width:100%;height:100px;"></textarea>';
+        echo '<p><button id="gwd-submit-prompt" class="button button-primary" type="button">' . esc_html__( 'Enviar', 'gemini-weaver-divi' ) . '</button></p>';
+        echo '<div id="gwd-status"></div>';
+    }
+}
+
+new GWD_Divi_Metabox();


### PR DESCRIPTION
## Summary
- add basic WP plugin structure `gemini-weaver-divi`
- implement plugin bootstrap with Divi-theme check
- create metabox class for prompt textarea and button
- add JS and CSS assets

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: numerous missing module errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ee67eacc08329ad40eadd30749eba