### PR TITLE
Implement AJAX bridge for Gemini plugin

### DIFF
--- a/gemini-weaver-divi/assets/js/gwd-main.js
+++ b/gemini-weaver-divi/assets/js/gwd-main.js
@@ -1,3 +1,25 @@
 (function($){
     console.log('Gemini Weaver Divi loaded');
+
+    $('#gwd-submit-prompt').on('click', function() {
+        var prompt = $('#gwd-prompt-input').val();
+        $('#gwd-status').text('Procesando...');
+
+        $.ajax({
+            method: 'POST',
+            url: gwd_ajax.ajax_url,
+            data: {
+                action: 'gwd_process_prompt',
+                prompt: prompt,
+                nonce: gwd_ajax.nonce
+            },
+            success: function(response) {
+                console.log(response);
+                $('#gwd-status').text('');
+            },
+            error: function() {
+                $('#gwd-status').text('Error al procesar el prompt.');
+            }
+        });
+    });
 })(jQuery);

--- a/gemini-weaver-divi/gemini-weaver-divi.php
+++ b/gemini-weaver-divi/gemini-weaver-divi.php
@@ -66,6 +66,32 @@ function gwd_enqueue_editor_assets( $hook ) {
     }
 
     wp_enqueue_script( 'gwd-main', GWD_URL . 'assets/js/gwd-main.js', array( 'jquery' ), '1.0.0', true );
+    wp_localize_script(
+        'gwd-main',
+        'gwd_ajax',
+        array(
+            'ajax_url' => admin_url( 'admin-ajax.php' ),
+            'nonce'    => wp_create_nonce( 'gwd_nonce' ),
+        )
+    );
     wp_enqueue_style( 'gwd-style', GWD_URL . 'assets/css/gwd-style.css', array(), '1.0.0' );
 }
 add_action( 'admin_enqueue_scripts', 'gwd_enqueue_editor_assets' );
+
+/**
+ * Process prompt sent from AJAX request.
+ */
+function gwd_process_prompt() {
+    check_ajax_referer( 'gwd_nonce', 'nonce' );
+
+    $prompt = isset( $_POST['prompt'] ) ? sanitize_text_field( wp_unslash( $_POST['prompt'] ) ) : '';
+
+    $response = array(
+        'status'  => 'success',
+        'message' => 'Prompt recibido: ' . $prompt,
+    );
+
+    echo json_encode( $response );
+    wp_die();
+}
+add_action( 'wp_ajax_gwd_process_prompt', 'gwd_process_prompt' );


### PR DESCRIPTION
## Summary
- add jQuery handler in `gwd-main.js` to send prompt via AJAX
- enqueue localized script and handle AJAX in `gemini-weaver-divi.php`

## Testing
- `npm run lint` *(fails: prompts ESLint setup)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_685ee97c84cc8329839a8e368d73acb9