### PR TITLE
Integrate Gemini API in Divi plugin

### DIFF
--- a/gemini-weaver-divi/assets/js/gwd-main.js
+++ b/gemini-weaver-divi/assets/js/gwd-main.js
@@ -16,6 +16,13 @@
             success: function(response) {
                 console.log(response);
                 $('#gwd-status').text('');
+                if (response.status === 'success') {
+                    var shortcode = response.shortcode || '';
+                    var $editor = jQuery('#content');
+                    $editor.val($editor.val() + "\n" + shortcode);
+                } else if (response.message) {
+                    $('#gwd-status').text(response.message);
+                }
             },
             error: function() {
                 $('#gwd-status').text('Error al procesar el prompt.');

--- a/gemini-weaver-divi/gemini-weaver-divi.php
+++ b/gemini-weaver-divi/gemini-weaver-divi.php
@@ -48,6 +48,8 @@ if ( ! gwd_is_divi_active() ) {
 
 // Include metabox class.
 require_once GWD_PATH . 'includes/class-divi-metabox.php';
+// Include Gemini connector.
+require_once GWD_PATH . 'includes/class-gemini-connector.php';
 
 /**
  * Enqueue scripts and styles on the page editor screen.
@@ -86,12 +88,21 @@ function gwd_process_prompt() {
 
     $prompt = isset( $_POST['prompt'] ) ? sanitize_text_field( wp_unslash( $_POST['prompt'] ) ) : '';
 
-    $response = array(
-        'status'  => 'success',
-        'message' => 'Prompt recibido: ' . $prompt,
-    );
+    $connector = new Gemini_Connector();
+    $shortcode = $connector->generate_divi_shortcodes( $prompt );
 
-    echo json_encode( $response );
+    if ( is_wp_error( $shortcode ) ) {
+        wp_send_json( array(
+            'status'  => 'error',
+            'message' => $shortcode->get_error_message(),
+        ) );
+    } else {
+        wp_send_json( array(
+            'status'    => 'success',
+            'shortcode' => $shortcode,
+        ) );
+    }
+
     wp_die();
 }
 add_action( 'wp_ajax_gwd_process_prompt', 'gwd_process_prompt' );

--- a/gemini-weaver-divi/includes/class-gemini-connector.php
+++ b/gemini-weaver-divi/includes/class-gemini-connector.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Handles communication with the Gemini API.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+class Gemini_Connector {
+
+    /**
+     * Retrieve the API key from options or constant.
+     *
+     * @return string|false
+     */
+    protected function get_api_key() {
+        $key = get_option( 'gwd_gemini_api_key' );
+        if ( ! $key && defined( 'GWD_GEMINI_API_KEY' ) ) {
+            $key = GWD_GEMINI_API_KEY;
+        }
+        return $key;
+    }
+
+    /**
+     * Generate Divi shortcodes using Gemini API.
+     *
+     * @param string $user_prompt User provided prompt.
+     *
+     * @return string|WP_Error Shortcode string or WP_Error on failure.
+     */
+    public function generate_divi_shortcodes( $user_prompt ) {
+        $api_key = $this->get_api_key();
+        if ( empty( $api_key ) ) {
+            return new WP_Error( 'no_api_key', __( 'Gemini API key not configured.', 'gemini-weaver-divi' ) );
+        }
+
+        $prompt = sprintf(
+            'Eres un asistente experto en el page builder Divi de WordPress. Tu única función es devolver shortcodes de Divi válidos basados en la petición del usuario. No añadas ninguna explicación, solo el código. Petición: %s',
+            $user_prompt
+        );
+
+        $body = array(
+            'contents' => array(
+                array(
+                    'parts' => array(
+                        array( 'text' => $prompt ),
+                    ),
+                ),
+            ),
+        );
+
+        $args = array(
+            'headers' => array(
+                'Content-Type'  => 'application/json',
+                'Authorization' => 'Bearer ' . $api_key,
+            ),
+            'body'    => wp_json_encode( $body ),
+            'timeout' => 20,
+        );
+
+        $response = wp_remote_post( 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent', $args );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $response_body = wp_remote_retrieve_body( $response );
+        if ( empty( $response_body ) ) {
+            return new WP_Error( 'empty_response', __( 'Empty response from Gemini API.', 'gemini-weaver-divi' ) );
+        }
+
+        $data = json_decode( $response_body, true );
+        if ( ! isset( $data['candidates'][0]['content']['parts'][0]['text'] ) ) {
+            return new WP_Error( 'invalid_response', __( 'Invalid response from Gemini API.', 'gemini-weaver-divi' ) );
+        }
+
+        $shortcode = trim( $data['candidates'][0]['content']['parts'][0]['text'] );
+        return $shortcode;
+    }
+}


### PR DESCRIPTION
## Summary
- add Gemini_Connector class to handle API calls
- insert generated shortcodes via AJAX using Gemini API
- inject shortcode result into WordPress editor

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685eec58484c8329bd556f6d3eefd48c