### PR TITLE
Add Gemini API settings page

### DIFF
--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -19,3 +19,8 @@
 - Use minimalist, geometric icons to complement the modern sans-serif typography and maintain a clean aesthetic.
 - Employ a clean, grid-based layout to ensure readability and a professional appearance. Prioritize clear information hierarchy to guide the user through the design process.
 - Incorporate subtle, non-intrusive animations to enhance user experience. For example, a gentle fade-in effect for generated elements or a smooth transition between prompts in the history panel.
+
+## Configuration
+
+1. In your WordPress admin dashboard, navigate to **Settings** ▸ **Gemini Weaver**.
+2. Enter your Google Gemini API key in the field provided and save the changes.

--- a/gemini-weaver-divi/gemini-weaver-divi.php
+++ b/gemini-weaver-divi/gemini-weaver-divi.php
@@ -52,6 +52,8 @@ require_once GWD_PATH . 'includes/class-divi-metabox.php';
 require_once GWD_PATH . 'includes/class-gemini-connector.php';
 // Divi parser for converting shortcodes to JSON and back.
 require_once GWD_PATH . 'includes/class-divi-parser.php';
+// Settings page for API configuration.
+require_once GWD_PATH . 'includes/gwd-settings.php';
 
 /**
  * Enqueue scripts and styles on the page editor screen.

--- a/gemini-weaver-divi/includes/gwd-settings.php
+++ b/gemini-weaver-divi/includes/gwd-settings.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Admin settings page for Gemini Weaver Divi plugin.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * Register plugin settings.
+ */
+function gwd_register_settings() {
+    register_setting( 'gwd_settings', 'gwd_gemini_api_key' );
+}
+add_action( 'admin_init', 'gwd_register_settings' );
+
+/**
+ * Render settings page.
+ */
+function gwd_settings_page() {
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'Gemini Weaver Settings', 'gemini-weaver-divi' ); ?></h1>
+        <form action="options.php" method="post">
+            <?php
+            settings_fields( 'gwd_settings' );
+            ?>
+            <table class="form-table" role="presentation">
+                <tr>
+                    <th scope="row">
+                        <label for="gwd_gemini_api_key"><?php esc_html_e( 'Gemini API Key', 'gemini-weaver-divi' ); ?></label>
+                    </th>
+                    <td>
+                        <input type="text" id="gwd_gemini_api_key" name="gwd_gemini_api_key" value="<?php echo esc_attr( get_option( 'gwd_gemini_api_key' ) ); ?>" class="regular-text" />
+                    </td>
+                </tr>
+            </table>
+            <?php submit_button(); ?>
+        </form>
+    </div>
+    <?php
+}
+
+/**
+ * Add settings page to the WordPress admin menu.
+ */
+function gwd_add_settings_page() {
+    add_options_page(
+        __( 'Gemini Weaver', 'gemini-weaver-divi' ),
+        __( 'Gemini Weaver', 'gemini-weaver-divi' ),
+        'manage_options',
+        'gwd-settings',
+        'gwd_settings_page'
+    );
+}
+add_action( 'admin_menu', 'gwd_add_settings_page' );


### PR DESCRIPTION
## Summary
- add a new settings page to configure the Gemini API key
- link the settings page from the plugin
- document how to enter the API key

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef57f814c832996891214919a11fd