### PR TITLE
Add preview container workflow for Gemini Weaver Divi

### DIFF
--- a/gemini-weaver-divi/assets/css/gwd-style.css
+++ b/gemini-weaver-divi/assets/css/gwd-style.css
@@ -1,3 +1,10 @@
 #gwd-status {
     margin-top: 10px;
 }
+
+#gwd-preview-container {
+    margin-top: 10px;
+    padding: 10px;
+    border: 1px solid #106ba3; /* blueprint blue */
+    background-color: #f5f8fa;
+}

--- a/gemini-weaver-divi/assets/js/gwd-main.js
+++ b/gemini-weaver-divi/assets/js/gwd-main.js
@@ -20,8 +20,8 @@
                 $('#gwd-status').text('');
                 if (response.status === 'success') {
                     var shortcode = response.shortcode || '';
-                    var $editor = jQuery('#content');
-                    $editor.val(shortcode);
+                    $('#gwd-preview-content').val(shortcode);
+                    $('#gwd-preview-container').show();
                 } else if (response.message) {
                     $('#gwd-status').text(response.message);
                 }
@@ -30,5 +30,16 @@
                 $('#gwd-status').text('Error al procesar el prompt.');
             }
         });
+    });
+
+    $('#gwd-apply-shortcode').on('click', function() {
+        var shortcode = $('#gwd-preview-content').val();
+        jQuery('#content').val(shortcode);
+        $('#gwd-preview-container').hide();
+    });
+
+    $('#gwd-cancel-shortcode').on('click', function() {
+        $('#gwd-preview-content').val('');
+        $('#gwd-preview-container').hide();
     });
 })(jQuery);

--- a/gemini-weaver-divi/includes/class-divi-metabox.php
+++ b/gemini-weaver-divi/includes/class-divi-metabox.php
@@ -35,6 +35,14 @@ class GWD_Divi_Metabox {
         echo '<input type="hidden" id="gwd-post-id" value="' . get_the_ID() . '" />';
         echo '<p><button id="gwd-submit-prompt" class="button button-primary" type="button">' . esc_html__( 'Enviar', 'gemini-weaver-divi' ) . '</button></p>';
         echo '<div id="gwd-status"></div>';
+        echo '<div id="gwd-preview-container" style="display:none;">';
+        echo '<p><strong>' . esc_html__( 'Preview', 'gemini-weaver-divi' ) . '</strong></p>';
+        echo '<textarea id="gwd-preview-content" style="width:100%;height:150px;" readonly></textarea>';
+        echo '<p>';
+        echo '<button id="gwd-apply-shortcode" class="button button-primary" type="button">' . esc_html__( 'Apply', 'gemini-weaver-divi' ) . '</button> ';
+        echo '<button id="gwd-cancel-shortcode" class="button" type="button">' . esc_html__( 'Cancel', 'gemini-weaver-divi' ) . '</button>';
+        echo '</p>';
+        echo '</div>';
     }
 }
 


### PR DESCRIPTION
## Summary
- display returned shortcode in a preview textarea instead of updating the editor
- add Apply and Cancel buttons in the metabox to accept or discard the previewed shortcode
- style preview container with a blueprint-like color scheme

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685ef6ab32b48329a9cb8a58372c79ea