### PR TITLE
Implement API key loading and saving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ next-env.d.ts
 # firebase
 firebase-debug.log
 firestore-debug.log
+api-key.txt

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,6 +1,10 @@
 'use server';
 
 import { generateFullPageLayoutFromPrompt } from "@/ai/flows/create-bulk-page-layout";
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const API_KEY_FILE = path.resolve(process.cwd(), 'api-key.txt');
 
 export async function processPrompt(prompt: string) {
   try {
@@ -13,5 +17,25 @@ export async function processPrompt(prompt: string) {
   } catch (error) {
     console.error('Error processing prompt:', error);
     return { error: 'An unexpected error occurred. Please try again later.' };
+  }
+}
+
+export async function loadApiKey() {
+  try {
+    const key = await fs.readFile(API_KEY_FILE, 'utf8');
+    return { data: key.trim() };
+  } catch (error) {
+    // File may not exist or reading failed
+    return { data: '' };
+  }
+}
+
+export async function saveApiKey(apiKey: string) {
+  try {
+    await fs.writeFile(API_KEY_FILE, apiKey, 'utf8');
+    return { success: true };
+  } catch (error) {
+    console.error('Error saving API key:', error);
+    return { error: 'Failed to save API key.' };
   }
 }

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -1,11 +1,66 @@
 'use client';
 
+import { useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useToast } from "@/hooks/use-toast";
 
 export default function SettingsPanel() {
+  const [apiKey, setApiKey] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const stored = localStorage.getItem('geminiApiKey');
+    if (stored) {
+      setApiKey(stored);
+    } else {
+      (async () => {
+        try {
+          const { loadApiKey } = await import('@/app/actions');
+          const result = await loadApiKey();
+          if (result.data) setApiKey(result.data);
+        } catch (e) {
+          console.error('Failed to load API key', e);
+        }
+      })();
+    }
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSaving(true);
+    try {
+      const { saveApiKey } = await import('@/app/actions');
+      const result = await saveApiKey(apiKey);
+      setIsSaving(false);
+
+      if (result.error) {
+        toast({
+          title: 'Error saving API key',
+          description: result.error,
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      localStorage.setItem('geminiApiKey', apiKey);
+      toast({
+        title: 'Settings saved',
+        description: 'Your API key has been stored.',
+      });
+    } catch (error) {
+      setIsSaving(false);
+      toast({
+        title: 'Unexpected error',
+        description: 'Something went wrong while saving.',
+        variant: 'destructive',
+      });
+    }
+  };
+
   return (
     <div className="p-1">
       <Card>
@@ -15,13 +70,23 @@ export default function SettingsPanel() {
             Enter your Google Gemini API key to connect your account.
           </CardDescription>
         </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="api-key">Gemini API Key</Label>
-            <Input id="api-key" type="password" placeholder="••••••••••••••••••••••" />
-          </div>
-          <Button>Save Settings</Button>
-        </CardContent>
+        <form onSubmit={handleSubmit}>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="api-key">Gemini API Key</Label>
+              <Input
+                id="api-key"
+                type="password"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder="*******************"
+              />
+            </div>
+            <Button type="submit" disabled={isSaving || !apiKey}>
+              {isSaving ? 'Saving...' : 'Save Settings'}
+            </Button>
+          </CardContent>
+        </form>
       </Card>
     </div>
   );


### PR DESCRIPTION
## Summary
- store API key server-side using a file
- add actions to load/save the API key
- load and save the key in the Settings panel with toast messages
- ignore the API key file in Git

## Testing
- `npm run lint` *(fails: Next.js prompts for ESLint setup)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_685efbced9a0832988937ec979ef21fc