### PR TITLE
Add Divi parser PHPUnit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ next-env.d.ts
 firebase-debug.log
 firestore-debug.log
 api-key.txt
+\.phpunit.result.cache

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+  <testsuites>
+    <testsuite name="Plugin Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/tests/DiviParserTest.php
+++ b/tests/DiviParserTest.php
@@ -1,0 +1,48 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class DiviParserTest extends TestCase {
+    public function testParseToJsonNestedShortcodes() {
+        $parser = new Divi_Parser();
+        $shortcode = '[et_pb_section foo="bar"][et_pb_row][et_pb_column type="text"][et_pb_text]Hi[/et_pb_text][/et_pb_column][/et_pb_row][/et_pb_section]';
+        $json = $parser->parse_to_json($shortcode);
+        $data = json_decode($json, true);
+        $expected = [
+            [
+                'type' => 'section',
+                'id'   => 'gwd-id-1',
+                'attrs' => ['foo' => 'bar'],
+                'content' => [
+                    [
+                        'type' => 'row',
+                        'id'   => 'gwd-id-2',
+                        'content' => [
+                            [
+                                'type' => 'column',
+                                'id'   => 'gwd-id-3',
+                                'attrs' => ['type' => 'text'],
+                                'content' => [
+                                    [
+                                        'type' => 'text',
+                                        'id'   => 'gwd-id-4',
+                                        'content' => 'Hi'
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+        $this->assertEquals($expected, $data);
+    }
+
+    public function testRoundTripIntegrity() {
+        $parser = new Divi_Parser();
+        $shortcode = '[et_pb_section][et_pb_row][et_pb_column][et_pb_text]Hello[/et_pb_text][/et_pb_column][/et_pb_row][/et_pb_section]';
+        $json = $parser->parse_to_json($shortcode);
+        $rebuilt = $parser->rebuild_from_json($json);
+        $this->assertEquals($shortcode, $rebuilt);
+    }
+}
+?>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,12 @@
+<?php
+require __DIR__ . '/wp-stubs.php';
+require __DIR__ . '/../gemini-weaver-divi/includes/class-divi-parser.php';
+
+// Register expected shortcodes for regex generation.
+$shortcode_tags = array(
+    'et_pb_section' => 'dummy',
+    'et_pb_row' => 'dummy',
+    'et_pb_column' => 'dummy',
+    'et_pb_text' => 'dummy',
+);
+?>

--- a/tests/wp-stubs.php
+++ b/tests/wp-stubs.php
@@ -1,0 +1,70 @@
+<?php
+if (!defined('ABSPATH')) {
+  define('ABSPATH', __DIR__.'/');
+}
+function get_shortcode_regex($tagnames=null){
+    global $shortcode_tags;
+    if (empty($tagnames)) {
+        $tagnames = array_keys($shortcode_tags ?? []);
+    }
+    $tagregexp = implode('|', array_map('preg_quote',$tagnames));
+    return '\\['
+        .'(\\[?)'
+        .'(' . $tagregexp . ')'
+        .'(?![\\w-])'
+        .'('
+        .'[^\\]\\/]*'
+        .'(?:'
+        .'\\/(?!\\])'
+        .'[^\\]\\/]*'
+        .')*?'
+        .')'
+        .'(?:'
+        .'(\\/)'
+        .'\\]'
+        .'|'
+        .'\\]'
+        .'(?:'
+        .'('
+        .'[^\\[]*+'
+        .'(?:'
+        .'\\[(?!\\/\\2\\])'
+        .'[^\\[]*+'
+        .')*+'
+        .')'
+        .'\\[\\/\\2\\]'
+        .')?'
+        .')'
+        .'(\\]?)';
+}
+function get_shortcode_atts_regex(){
+    return '/([\w-]+)\s*=\s*"([^"]*)"(?:\s|$)|([\w-]+)\s*=\s*\'([^\']*)\'(?:\s|$)|([\w-]+)\s*=\s*([^\s\'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|\'([^\']*)\'(?:\s|$)|(\S+)(?:\s|$)/';
+}
+function shortcode_parse_atts($text){
+    $atts=array();
+    $pattern=get_shortcode_atts_regex();
+    $text=preg_replace("/[\x{00a0}\x{200b}]+/u",' ',$text);
+    if(preg_match_all($pattern,$text,$match,PREG_SET_ORDER)){
+        foreach($match as $m){
+            if(!empty($m[1])){ $atts[strtolower($m[1])] = stripcslashes($m[2]); }
+            elseif(!empty($m[3])){ $atts[strtolower($m[3])] = stripcslashes($m[4]); }
+            elseif(!empty($m[5])){ $atts[strtolower($m[5])] = stripcslashes($m[6]); }
+            elseif(isset($m[7]) && strlen($m[7])){ $atts[] = stripcslashes($m[7]); }
+            elseif(isset($m[8]) && strlen($m[8])){ $atts[] = stripcslashes($m[8]); }
+            elseif(isset($m[9])){ $atts[] = stripcslashes($m[9]); }
+        }
+        foreach($atts as &$value){
+            if(str_contains($value,'<')){
+                if(1!==preg_match('/^[^<]*+(?:<[^>]*+>[^<]*+)*+$/',$value)){
+                    $value='';
+                }
+            }
+        }
+    } else {
+        $atts=ltrim($text);
+    }
+    return $atts;
+}
+function wp_json_encode($data){ return json_encode($data); }
+function esc_attr($text){ return htmlspecialchars($text,ENT_QUOTES); }
+?>


### PR DESCRIPTION
## Summary
- add PHPUnit configuration
- stub minimal WordPress functions for testing
- bootstrap parser tests
- implement tests for parse_to_json and rebuild_from_json

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685f06a59dac8329b0a6356d494467c1