### PR TITLE
Add REST API for Gemini key and integrate with Next.js

### DIFF
--- a/gemini-weaver-divi/gemini-weaver-divi.php
+++ b/gemini-weaver-divi/gemini-weaver-divi.php
@@ -54,6 +54,8 @@ require_once GWD_PATH . 'includes/class-gemini-connector.php';
 require_once GWD_PATH . 'includes/class-divi-parser.php';
 // Settings page for API configuration.
 require_once GWD_PATH . 'includes/gwd-settings.php';
+// REST API endpoints for key management.
+require_once GWD_PATH . 'includes/gwd-rest-api.php';
 
 /**
  * Enqueue scripts and styles on the page editor screen.

--- a/gemini-weaver-divi/includes/gwd-rest-api.php
+++ b/gemini-weaver-divi/includes/gwd-rest-api.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * REST API endpoints for Gemini Weaver Divi plugin.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+function gwd_register_rest_routes() {
+    register_rest_route( 'gwd/v1', '/gemini-key', array(
+        'methods'             => array( 'GET', 'POST' ),
+        'permission_callback' => function() {
+            return current_user_can( 'manage_options' );
+        },
+        'callback'            => 'gwd_handle_gemini_key',
+    ) );
+}
+add_action( 'rest_api_init', 'gwd_register_rest_routes' );
+
+function gwd_handle_gemini_key( WP_REST_Request $request ) {
+    if ( 'GET' === $request->get_method() ) {
+        $key = get_option( 'gwd_gemini_api_key', '' );
+        return rest_ensure_response( array( 'key' => $key ) );
+    }
+
+    if ( 'POST' === $request->get_method() ) {
+        $key = sanitize_text_field( $request->get_param( 'key' ) );
+        update_option( 'gwd_gemini_api_key', $key );
+        return rest_ensure_response( array( 'success' => true ) );
+    }
+
+    return rest_ensure_response( array( 'success' => false ) );
+}

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -13,20 +13,21 @@ export default function SettingsPanel() {
   const { toast } = useToast();
 
   useEffect(() => {
-    const stored = localStorage.getItem('geminiApiKey');
-    if (stored) {
-      setApiKey(stored);
-    } else {
-      (async () => {
-        try {
-          const { loadApiKey } = await import('@/app/actions');
-          const result = await loadApiKey();
-          if (result.data) setApiKey(result.data);
-        } catch (e) {
-          console.error('Failed to load API key', e);
+    (async () => {
+      try {
+        const { loadApiKey } = await import('@/app/actions');
+        const result = await loadApiKey();
+        if (result.data) {
+          setApiKey(result.data);
+          localStorage.setItem('geminiApiKey', result.data);
+          return;
         }
-      })();
-    }
+      } catch (e) {
+        console.error('Failed to load API key from server', e);
+      }
+      const stored = localStorage.getItem('geminiApiKey');
+      if (stored) setApiKey(stored);
+    })();
   }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {


### PR DESCRIPTION
## Summary
- expose a WordPress REST API endpoint for reading/writing `gwd_gemini_api_key`
- register new endpoint in the plugin loader
- update Next.js server actions to call the WordPress API
- read/write the key from the settings panel using the new API

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_685f084ac594832980cd37d758201585