### PR TITLE
Add log viewer in settings with error filter

### DIFF
--- a/gemini-weaver-divi/includes/class-gemini-connector.php
+++ b/gemini-weaver-divi/includes/class-gemini-connector.php
@@ -35,6 +35,8 @@ class Gemini_Connector {
             return new WP_Error( 'no_api_key', __( 'Gemini API key not configured.', 'gemini-weaver-divi' ) );
         }
 
+        gwd_log( 'Sending prompt: ' . $prompt );
+
         $body = array(
             'contents' => array(
                 array(
@@ -57,20 +59,24 @@ class Gemini_Connector {
         $response = wp_remote_post( 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent', $args );
 
         if ( is_wp_error( $response ) ) {
+            gwd_log( 'Request error: ' . $response->get_error_message(), 'error' );
             return $response;
         }
 
         $response_body = wp_remote_retrieve_body( $response );
         if ( empty( $response_body ) ) {
+            gwd_log( 'Empty response from Gemini API.', 'error' );
             return new WP_Error( 'empty_response', __( 'Empty response from Gemini API.', 'gemini-weaver-divi' ) );
         }
 
         $data = json_decode( $response_body, true );
         if ( ! isset( $data['candidates'][0]['content']['parts'][0]['text'] ) ) {
+            gwd_log( 'Invalid response from Gemini API.', 'error' );
             return new WP_Error( 'invalid_response', __( 'Invalid response from Gemini API.', 'gemini-weaver-divi' ) );
         }
 
         $text = trim( $data['candidates'][0]['content']['parts'][0]['text'] );
+        gwd_log( 'Received response: ' . $text );
         return $text;
     }
 

--- a/gemini-weaver-divi/includes/gwd-logger.php
+++ b/gemini-weaver-divi/includes/gwd-logger.php
@@ -1,0 +1,49 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * Log a message to the Gemini Weaver log file.
+ *
+ * @param string $message Message to log.
+ * @param string $level   Log level (info, error, etc).
+ */
+function gwd_log( $message, $level = 'info' ) {
+    $upload_dir = wp_upload_dir();
+    $log_file   = trailingslashit( $upload_dir['basedir'] ) . 'gwd.log';
+
+    $entry = sprintf( "[%s] [%s] %s\n", current_time( 'mysql' ), strtoupper( $level ), $message );
+    error_log( $entry, 3, $log_file );
+}
+
+/**
+ * Retrieve log entries.
+ *
+ * @param bool $errors_only Whether to return only error entries.
+ * @return array Array of log lines.
+ */
+function gwd_get_log_entries( $errors_only = false ) {
+    $upload_dir = wp_upload_dir();
+    $log_file   = trailingslashit( $upload_dir['basedir'] ) . 'gwd.log';
+
+    if ( ! file_exists( $log_file ) ) {
+        return array();
+    }
+
+    $lines = file( $log_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES );
+    if ( ! $lines ) {
+        return array();
+    }
+
+    if ( $errors_only ) {
+        $lines = array_filter(
+            $lines,
+            function ( $line ) {
+                return false !== stripos( $line, 'ERROR' );
+            }
+        );
+    }
+
+    return array_reverse( $lines );
+}

--- a/gemini-weaver-divi/includes/gwd-settings.php
+++ b/gemini-weaver-divi/includes/gwd-settings.php
@@ -18,26 +18,66 @@ add_action( 'admin_init', 'gwd_register_settings' );
 /**
  * Render settings page.
  */
+function gwd_render_api_settings() {
+    ?>
+    <form action="options.php" method="post">
+        <?php
+        settings_fields( 'gwd_settings' );
+        ?>
+        <table class="form-table" role="presentation">
+            <tr>
+                <th scope="row">
+                    <label for="gwd_gemini_api_key"><?php esc_html_e( 'Gemini API Key', 'gemini-weaver-divi' ); ?></label>
+                </th>
+                <td>
+                    <input type="text" id="gwd_gemini_api_key" name="gwd_gemini_api_key" value="<?php echo esc_attr( get_option( 'gwd_gemini_api_key' ) ); ?>" class="regular-text" />
+                </td>
+            </tr>
+        </table>
+        <?php submit_button(); ?>
+    </form>
+    <?php
+}
+
+function gwd_render_logs_page() {
+    $errors_only = isset( $_GET['errors_only'] ) && '1' === $_GET['errors_only'];
+    $logs        = gwd_get_log_entries( $errors_only );
+    ?>
+    <form method="get" style="margin-bottom:15px;">
+        <input type="hidden" name="page" value="gwd-settings" />
+        <input type="hidden" name="tab" value="logs" />
+        <label>
+            <input type="checkbox" name="errors_only" value="1" <?php checked( $errors_only ); ?> />
+            <?php esc_html_e( 'Show only errors', 'gemini-weaver-divi' ); ?>
+        </label>
+        <?php submit_button( __( 'Filter', 'gemini-weaver-divi' ), 'secondary', '', false ); ?>
+    </form>
+    <pre style="max-height:400px;overflow:auto;background:#fff;padding:10px;border:1px solid #ccc;">
+<?php echo esc_html( implode( "\n", $logs ) ); ?>
+    </pre>
+    <?php
+}
+
 function gwd_settings_page() {
+    $tab = isset( $_GET['tab'] ) ? sanitize_text_field( $_GET['tab'] ) : 'settings';
     ?>
     <div class="wrap">
         <h1><?php esc_html_e( 'Gemini Weaver Settings', 'gemini-weaver-divi' ); ?></h1>
-        <form action="options.php" method="post">
-            <?php
-            settings_fields( 'gwd_settings' );
-            ?>
-            <table class="form-table" role="presentation">
-                <tr>
-                    <th scope="row">
-                        <label for="gwd_gemini_api_key"><?php esc_html_e( 'Gemini API Key', 'gemini-weaver-divi' ); ?></label>
-                    </th>
-                    <td>
-                        <input type="text" id="gwd_gemini_api_key" name="gwd_gemini_api_key" value="<?php echo esc_attr( get_option( 'gwd_gemini_api_key' ) ); ?>" class="regular-text" />
-                    </td>
-                </tr>
-            </table>
-            <?php submit_button(); ?>
-        </form>
+        <h2 class="nav-tab-wrapper">
+            <a href="?page=gwd-settings&tab=settings" class="nav-tab <?php echo 'settings' === $tab ? 'nav-tab-active' : ''; ?>">
+                <?php esc_html_e( 'API Settings', 'gemini-weaver-divi' ); ?>
+            </a>
+            <a href="?page=gwd-settings&tab=logs" class="nav-tab <?php echo 'logs' === $tab ? 'nav-tab-active' : ''; ?>">
+                <?php esc_html_e( 'Logs', 'gemini-weaver-divi' ); ?>
+            </a>
+        </h2>
+        <?php
+        if ( 'logs' === $tab ) {
+            gwd_render_logs_page();
+        } else {
+            gwd_render_api_settings();
+        }
+        ?>
     </div>
     <?php
 }


### PR DESCRIPTION
## Summary
- implement simple logger and log retrieval helpers
- expose log viewer tab with error-only filter
- add logging in prompt processing and Gemini connector

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685f159d6ff8832997880cbf5eda5b52